### PR TITLE
Do not require a TTY to for `docker run`

### DIFF
--- a/debian/build/Makefile
+++ b/debian/build/Makefile
@@ -50,7 +50,7 @@ upload: version tools
 
 runcontainer:
 	mkdir -p /tmp/consul-deb
-	docker run -it --rm \
+	docker run -i --rm \
 		-v ~/.devscripts:/root/.devscripts \
 		-v ~/.gnupg:/root/.gnupg \
 		-v $(PKGDIR):/opt/consul-deb:ro \


### PR DESCRIPTION
The `-t` flag fails when running through Jenkins because we don't have a TTY.

```
docker run -it --rm \
		-v ~/.devscripts:/root/.devscripts \
		-v ~/.gnupg:/root/.gnupg \
		-v /var/lib/jenkins/workspace/build-hashicorp-consul-deb/debian/build/../..:/opt/consul-deb:ro \
		-v /tmp/consul-deb:/tmp/consul-deb \
		 \
		ubuntu:yakkety-consul-deb 
cannot enable tty mode on non tty input
```